### PR TITLE
Argument feature

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -79,6 +79,23 @@ func (lgr *Ledger) CreateAccountHash(fullname, fpath string, initBalance float64
 }
 
 /**
+ * @brief:  Get the account number given the ledger notebook
+ *
+ * @arg:    filepath - Path to the ledger notebook
+ *
+ * @return: The account number of the filepath
+ **/
+func (lgr *Ledger) GetAcctNum(filepath string) string {
+    for key, acct := range lgr.Accounts {
+        if acct.Filepath == filepath {
+            return key
+        }
+    }
+
+    return ""
+}
+
+/**
  * @brief:  Check if the given account number is valid in the ledger
  *
  * @arg:    acctNum - Account number to check if found/valid

--- a/accounts.go
+++ b/accounts.go
@@ -49,7 +49,7 @@ type Account struct {
 func (lgr *Ledger) CreateAccountHash(fullname, fpath string, initBalance float64) string {
     /* Calculate the hash and then add it to the ledger */
     var h maphash.Hash
-    h.WriteString(fullname + GetDate() + fmt.Sprintf("%f", initBalance))
+    h.WriteString(fullname + GetDate(DATE_TIME) + fmt.Sprintf("%f", initBalance))
     acctNum := fmt.Sprintf("%x", h.Sum64())
     lgr.Accounts[acctNum] = &Account{fpath, fullname, []EntryItem{}}
 
@@ -67,7 +67,7 @@ func (lgr *Ledger) CreateAccountHash(fullname, fpath string, initBalance float64
     }
 
     /* Add the first entry with the initial balance */
-    newEntry := fmt.Sprintf("%s:---:---:Income:0.0:%0.2f", GetDate(), initBalance)
+    newEntry := fmt.Sprintf("%s:---:---:Income:0.0:%0.2f", GetDate(DATE_TIME), initBalance)
     logger.Printf("New account created for '%s -- %s': %s\n", fullname, acctNum, newEntry)
     if _, err := f.Write([]byte(newEntry + "\n")); err != nil {
         f.Close()

--- a/arguments.go
+++ b/arguments.go
@@ -66,7 +66,12 @@ func (lgr *Ledger) ArgumentParser() {
     flag.BoolVar(&createAccount, "new-acct", false, NEWACCOUNT_DESC)
     flag.Parse()
 
-    if notebook == "" && !createAccount {
+    /* Either the ledger or create new account flag needs to be passed, not both */
+    if notebook != "" && createAccount {
+        fmt.Println("Error: Cannot read ledger notebook and create account.")
+        fmt.Println("       Only one can be done at a time")
+        os.Exit(1)
+    } else if notebook == "" && !createAccount {
         fmt.Println("Error: Missing ledger notebook")
         flag.PrintDefaults()
         os.Exit(1)
@@ -81,11 +86,11 @@ func (lgr *Ledger) ArgumentParser() {
         lgr.CreateAccountHash(fullname, notebook, balance)
     }
 
-    /* Read the ledger notebook from above */
+    /* Read the ledger notebook */
     lgr.ReadLedger(notebook)
     acctNum := lgr.GetAcctNum(notebook)
 
-    /* Add to new items to the ledger, one expense and one income type */
+    /* Add new entry to the ledger */
     if addEntry {
         transaction := readBuf("Enter area of transaction", true)
         location := readBuf("Enter area of location of transaction", false)

--- a/arguments.go
+++ b/arguments.go
@@ -11,7 +11,7 @@ import (
 const (
     LEDGER_DESC string = "The ledger notebook"
     PRINTPRETTY_DESC string = "Print the ledger notebook pretty"
-    PRINTTABLE_DESC string = "Print the ledger notebook to a markdown table\nNote: You can pass an output markdown file name"
+    PRINTTABLE_DESC string = "Print the ledger notebook to a markdown table\nNote: Output file is required"
     ADDENTRY_DESC string = "Add a new entry to the ledger notebook\nNote: Ledger notebook is required"
     NEWACCOUNT_DESC string = "Create a new account"
 )
@@ -62,13 +62,8 @@ func (lgr *Ledger) ArgumentParser() {
 
     /* Read the ledger notebook from above */
     lgr.ReadLedger(notebook)
-    lgr.CreateAccount()
-    lgr.AddToEntry()
-    lgr.PrintPretty()
-    lgr.PrintTable()
-}
+    acctNum := lgr.GetAcctNum(notebook)
 
-func (lgr *Ledger) CreateAccount() {
     /* Create a new account */
     if createAccount {
         fullname := readBuf("Enter the full name of the new account", true)
@@ -77,29 +72,23 @@ func (lgr *Ledger) CreateAccount() {
         notebook = strings.ToLower(strings.Replace(notebook, " ", "-", -1))
         lgr.CreateAccountHash(fullname, notebook, balance)
     }
-}
 
-func (lgr *Ledger) AddToEntry() {
     /* Add to new items to the ledger, one expense and one income type */
     if addEntry {
         transaction = readBuf("Enter area of transaction", true)
         location = readBuf("Enter area of location of transaction", false)
         detail = readBuf("Enter details of transaction", true)
         cost = StrToFloat(readBuf("Enter cost of transaction", true))
-        lgr.AddEntry(lgr.GetAcctNum(notebook), transaction, location, detail, cost)
+        lgr.AddEntry(acctNum, transaction, location, detail, cost)
     }
-}
 
-func (lgr Ledger) PrintPretty() {
     /* Print the ledger out pretty */
     if printPretty {
         lgr.PrintLedger()
     }
-}
 
-func (lgr Ledger) PrintTable() {
     /* Print the information into a markdown table */
     if printTable != "" {
-        lgr.PrintToTable(lgr.GetAcctNum(notebook), printTable)
+        lgr.PrintToTable(acctNum, printTable)
     }
 }

--- a/arguments.go
+++ b/arguments.go
@@ -1,0 +1,105 @@
+package ledger
+
+import (
+    "bufio"
+    "flag"
+    "fmt"
+    "os"
+    "strings"
+)
+
+const (
+    LEDGER_DESC string = "The ledger notebook"
+    PRINTPRETTY_DESC string = "Print the ledger notebook pretty"
+    PRINTTABLE_DESC string = "Print the ledger notebook to a markdown table\nNote: You can pass an output markdown file name"
+    ADDENTRY_DESC string = "Add a new entry to the ledger notebook\nNote: Ledger notebook is required"
+    NEWACCOUNT_DESC string = "Create a new account"
+)
+
+var (
+    notebook    string
+    printPretty bool
+    printTable  string
+    addEntry    bool
+    createAccount  bool
+    transaction string
+    location    string
+    detail      string
+    cost        float64
+)
+
+func readBuf(prompt string, required bool) string {
+        text := ""
+        for {
+            reader := bufio.NewReader(os.Stdin)
+            fmt.Print(prompt + " > ")
+            text , _ = reader.ReadString('\n')
+            text = strings.Replace(text, "\n", "", -1)
+
+            if required && text == "" {
+                fmt.Println("Error: input required, none given")
+            } else {
+                break
+            }
+        }
+
+        return text
+}
+
+func (lgr *Ledger) ArgumentParser() {
+    flag.StringVar(&notebook, "l", "", LEDGER_DESC)
+    flag.BoolVar(&printPretty, "pp", false, PRINTPRETTY_DESC)
+    flag.StringVar(&printTable, "pt", "", PRINTTABLE_DESC)
+    flag.BoolVar(&addEntry, "add-entry", false, ADDENTRY_DESC)
+    flag.BoolVar(&createAccount, "new-acct", false, NEWACCOUNT_DESC)
+    flag.Parse()
+
+    if notebook == "" && !createAccount {
+        fmt.Println("Error: Missing ledger notebook")
+        flag.PrintDefaults()
+        os.Exit(1)
+    }
+
+    /* Read the ledger notebook from above */
+    lgr.ReadLedger(notebook)
+    lgr.CreateAccount()
+    lgr.AddToEntry()
+    lgr.PrintPretty()
+    lgr.PrintTable()
+}
+
+func (lgr *Ledger) CreateAccount() {
+    /* Create a new account */
+    if createAccount {
+        fullname := readBuf("Enter the full name of the new account", true)
+        balance := StrToFloat(readBuf("Enter initial balance for " + fullname + " account", true))
+        notebook = fullname + ".lgr"
+        notebook = strings.ToLower(strings.Replace(notebook, " ", "-", -1))
+        lgr.CreateAccountHash(fullname, notebook, balance)
+    }
+}
+
+func (lgr *Ledger) AddToEntry() {
+    /* Add to new items to the ledger, one expense and one income type */
+    if addEntry {
+        transaction = readBuf("Enter area of transaction", true)
+        location = readBuf("Enter area of location of transaction", false)
+        detail = readBuf("Enter details of transaction", true)
+        cost = StrToFloat(readBuf("Enter cost of transaction", true))
+        lgr.AddEntry(lgr.GetAcctNum(notebook), transaction, location, detail, cost)
+    }
+}
+
+func (lgr Ledger) PrintPretty() {
+    /* Print the ledger out pretty */
+    if printPretty {
+        lgr.PrintLedger()
+    }
+}
+
+func (lgr Ledger) PrintTable() {
+    /* Print the information into a markdown table */
+    if printTable != "" {
+        lgr.PrintToTable(lgr.GetAcctNum(notebook), printTable)
+    }
+}

--- a/arguments.go
+++ b/arguments.go
@@ -16,37 +16,49 @@ const (
     NEWACCOUNT_DESC string = "Create a new account"
 )
 
-var (
-    notebook    string
-    printPretty bool
-    printTable  string
-    addEntry    bool
-    createAccount  bool
-    transaction string
-    location    string
-    detail      string
-    cost        float64
-)
-
+/***
+ * @brief:  Reads input from the user
+ *
+ * @arg:    prompt - String to ask the user
+ * @arg:    required - Input is required if true
+ *
+ * @return: The user response from the prompt
+ ***/
 func readBuf(prompt string, required bool) string {
-        text := ""
+        response := ""
         for {
             reader := bufio.NewReader(os.Stdin)
             fmt.Print(prompt + " > ")
-            text , _ = reader.ReadString('\n')
-            text = strings.Replace(text, "\n", "", -1)
+            response , _ = reader.ReadString('\n')
+            response = strings.Replace(response, "\n", "", -1)
 
-            if required && text == "" {
+            if required && response == "" {
                 fmt.Println("Error: input required, none given")
             } else {
                 break
             }
         }
 
-        return text
+        return response
 }
 
+/***
+ * @brief:  Checks to see if user has passed any flags.
+ *          -l: The ledger notebook
+ *          -pp: Print the ledger notebook out pretty
+ *          -pt: Save the ledger notebook as a markdown table
+ *          -add-entry: Adds an entry to the ledger notebook
+ *          -new-acct: Creates a new account and ledger notebook
+ ***/
 func (lgr *Ledger) ArgumentParser() {
+    var (
+        notebook    string
+        printPretty bool
+        printTable  string
+        addEntry    bool
+        createAccount  bool
+    )
+
     flag.StringVar(&notebook, "l", "", LEDGER_DESC)
     flag.BoolVar(&printPretty, "pp", false, PRINTPRETTY_DESC)
     flag.StringVar(&printTable, "pt", "", PRINTTABLE_DESC)
@@ -60,10 +72,6 @@ func (lgr *Ledger) ArgumentParser() {
         os.Exit(1)
     }
 
-    /* Read the ledger notebook from above */
-    lgr.ReadLedger(notebook)
-    acctNum := lgr.GetAcctNum(notebook)
-
     /* Create a new account */
     if createAccount {
         fullname := readBuf("Enter the full name of the new account", true)
@@ -73,12 +81,16 @@ func (lgr *Ledger) ArgumentParser() {
         lgr.CreateAccountHash(fullname, notebook, balance)
     }
 
+    /* Read the ledger notebook from above */
+    lgr.ReadLedger(notebook)
+    acctNum := lgr.GetAcctNum(notebook)
+
     /* Add to new items to the ledger, one expense and one income type */
     if addEntry {
-        transaction = readBuf("Enter area of transaction", true)
-        location = readBuf("Enter area of location of transaction", false)
-        detail = readBuf("Enter details of transaction", true)
-        cost = StrToFloat(readBuf("Enter cost of transaction", true))
+        transaction := readBuf("Enter area of transaction", true)
+        location := readBuf("Enter area of location of transaction", false)
+        detail := readBuf("Enter details of transaction", true)
+        cost := StrToFloat(readBuf("Enter cost of transaction", true))
         lgr.AddEntry(acctNum, transaction, location, detail, cost)
     }
 

--- a/example/main.go
+++ b/example/main.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+    "bufio"
+    "flag"
     "fmt"
+    "os"
+    "strings"
 
     lgr "github.com/loerac/ledger"
 )
@@ -9,31 +13,94 @@ import (
 const (
     LEDGER1 string = "notebook1.lgr"
     LEDGER2 string = "notebook2.lgr"
+    NOTEBOOK_DESC string = "The ledger notebook"
+    PRINTPRETTY_DESC string = "Print the ledger notebook pretty"
+    PRINTTABLE_DESC string = "Print the ledger notebook to a markdown table\nNote: You can pass an output markdown file name"
+    ADDENTRY_DESC string = "Add a new entry to the ledger notebook\nNote: Ledger notebook is required"
+    NEWACCOUNT_DESC string = "Create a new account"
 )
 
+var (
+    notebook    string
+    printPretty bool
+    printTable  string
+    addEntry    bool
+    createAccount  bool
+    transaction string
+    location    string
+    detail      string
+    cost        float64
+)
+
+func readBuf(prompt string, required bool) string {
+        text := ""
+        for {
+            reader := bufio.NewReader(os.Stdin)
+            fmt.Print(prompt + " > ")
+            text , _ = reader.ReadString('\n')
+            text = strings.Replace(text, "\n", "", -1)
+
+            if required && text == "" {
+                fmt.Println("Error: input required, none given")
+            } else {
+                break
+            }
+        }
+
+        return text
+}
+
 func main() {
+    flag.StringVar(&notebook, "ledger", "", NOTEBOOK_DESC)
+    flag.StringVar(&notebook, "l", "", NOTEBOOK_DESC + " (Short-hand)")
+    flag.BoolVar(&printPretty, "print-pretty", false, PRINTPRETTY_DESC)
+    flag.BoolVar(&printPretty, "pp", false, PRINTPRETTY_DESC + " (Short-hand)")
+    flag.StringVar(&printTable, "print-table", "", PRINTTABLE_DESC)
+    flag.StringVar(&printTable, "pt", "", PRINTTABLE_DESC + " (Short-hand)")
+    flag.BoolVar(&addEntry, "entry", false, ADDENTRY_DESC)
+    flag.BoolVar(&addEntry, "e", false, ADDENTRY_DESC + " (Short-hand)")
+    flag.BoolVar(&createAccount, "account", false, NEWACCOUNT_DESC)
+    flag.BoolVar(&createAccount, "a", false, NEWACCOUNT_DESC + " (Short-hand)")
+    flag.Parse()
+
+    if notebook == "" && !createAccount {
+        fmt.Println("Error: Missing ledger notebook")
+        flag.PrintDefaults()
+        os.Exit(1)
+    }
+
     /* Get a new init ledger struct */
     ledger := lgr.NewLedger()
 
-    /* Read the ledger notebook from above */
-    ledger.ReadLedger(LEDGER1, LEDGER2)
+    /* Create a new account */
+    if createAccount {
+        fullname := readBuf("Enter the full name of the new account", true)
+        balance := lgr.StrToFloat(readBuf("Enter initial balance for " + fullname + " account", true))
+        notebook = fullname + ".lgr"
+        notebook = strings.ToLower(strings.Replace(notebook, " ", "-", -1))
+        ledger.CreateAccountHash(fullname, notebook, balance)
+    }
 
-    /* Print the ledger out pretty */
-    ledger.PrintLedger()
+    /* Read the ledger notebook from above */
+    ledger.ReadLedger(notebook)
+    acctNum := ledger.GetAcctNum(notebook)
 
     /* Add to new items to the ledger, one expense and one income type */
-    ledger.AddEntry("5524c5d66aeee973", "Store store", "S 456 St., Small Town, Big State", "Shopping", -19)
-    ledger.AddEntry("936e1204e7b8c686", "Farm Big Lot", "", "Farm equipment", 19)
+    if addEntry {
+        transaction = readBuf("Enter area of transaction", true)
+        location = readBuf("Enter area of location of transaction", false)
+        detail = readBuf("Enter details of transaction", true)
+        cost = lgr.StrToFloat(readBuf("Enter cost of transaction", true))
+        ledger.AddEntry(acctNum, transaction, location, detail, cost)
+    }
 
-    /* Print the information on an account */
-    ledger.PrintLedgerAccount("5524c5d66aeee973")
+    /* Print the ledger out pretty */
+    if printPretty {
+        ledger.PrintLedger()
+    }
 
     /* Print the information into a markdown table */
-    ledger.PrintToTable("936e1204e7b8c686", "ledger-table")
-
-    /* Add a new account */
-    fullname := "Jimmy Johns"
-    acctNum := ledger.CreateAccountHash(fullname, "notebook3.lgr", 12.90)
-    fmt.Println("New account number for", fullname, "-", acctNum)
-    ledger.AddEntry(acctNum, "Subway", "Subway 456 Rd., Subs City, Subs State", "Subs", -6.12)
+    if printTable != "" {
+        ledger.PrintToTable(acctNum, printTable)
+    }
 }

--- a/example/main.go
+++ b/example/main.go
@@ -1,106 +1,18 @@
 package main
 
 import (
-    "bufio"
-    "flag"
-    "fmt"
-    "os"
-    "strings"
-
     lgr "github.com/loerac/ledger"
 )
 
 const (
     LEDGER1 string = "notebook1.lgr"
     LEDGER2 string = "notebook2.lgr"
-    NOTEBOOK_DESC string = "The ledger notebook"
-    PRINTPRETTY_DESC string = "Print the ledger notebook pretty"
-    PRINTTABLE_DESC string = "Print the ledger notebook to a markdown table\nNote: You can pass an output markdown file name"
-    ADDENTRY_DESC string = "Add a new entry to the ledger notebook\nNote: Ledger notebook is required"
-    NEWACCOUNT_DESC string = "Create a new account"
 )
-
-var (
-    notebook    string
-    printPretty bool
-    printTable  string
-    addEntry    bool
-    createAccount  bool
-    transaction string
-    location    string
-    detail      string
-    cost        float64
-)
-
-func readBuf(prompt string, required bool) string {
-        text := ""
-        for {
-            reader := bufio.NewReader(os.Stdin)
-            fmt.Print(prompt + " > ")
-            text , _ = reader.ReadString('\n')
-            text = strings.Replace(text, "\n", "", -1)
-
-            if required && text == "" {
-                fmt.Println("Error: input required, none given")
-            } else {
-                break
-            }
-        }
-
-        return text
-}
 
 func main() {
-    flag.StringVar(&notebook, "ledger", "", NOTEBOOK_DESC)
-    flag.StringVar(&notebook, "l", "", NOTEBOOK_DESC + " (Short-hand)")
-    flag.BoolVar(&printPretty, "print-pretty", false, PRINTPRETTY_DESC)
-    flag.BoolVar(&printPretty, "pp", false, PRINTPRETTY_DESC + " (Short-hand)")
-    flag.StringVar(&printTable, "print-table", "", PRINTTABLE_DESC)
-    flag.StringVar(&printTable, "pt", "", PRINTTABLE_DESC + " (Short-hand)")
-    flag.BoolVar(&addEntry, "entry", false, ADDENTRY_DESC)
-    flag.BoolVar(&addEntry, "e", false, ADDENTRY_DESC + " (Short-hand)")
-    flag.BoolVar(&createAccount, "account", false, NEWACCOUNT_DESC)
-    flag.BoolVar(&createAccount, "a", false, NEWACCOUNT_DESC + " (Short-hand)")
-    flag.Parse()
-
-    if notebook == "" && !createAccount {
-        fmt.Println("Error: Missing ledger notebook")
-        flag.PrintDefaults()
-        os.Exit(1)
-    }
-
     /* Get a new init ledger struct */
     ledger := lgr.NewLedger()
 
-    /* Create a new account */
-    if createAccount {
-        fullname := readBuf("Enter the full name of the new account", true)
-        balance := lgr.StrToFloat(readBuf("Enter initial balance for " + fullname + " account", true))
-        notebook = fullname + ".lgr"
-        notebook = strings.ToLower(strings.Replace(notebook, " ", "-", -1))
-        ledger.CreateAccountHash(fullname, notebook, balance)
-    }
-
-    /* Read the ledger notebook from above */
-    ledger.ReadLedger(notebook)
-    acctNum := ledger.GetAcctNum(notebook)
-
-    /* Add to new items to the ledger, one expense and one income type */
-    if addEntry {
-        transaction = readBuf("Enter area of transaction", true)
-        location = readBuf("Enter area of location of transaction", false)
-        detail = readBuf("Enter details of transaction", true)
-        cost = lgr.StrToFloat(readBuf("Enter cost of transaction", true))
-        ledger.AddEntry(acctNum, transaction, location, detail, cost)
-    }
-
-    /* Print the ledger out pretty */
-    if printPretty {
-        ledger.PrintLedger()
-    }
-
-    /* Print the information into a markdown table */
-    if printTable != "" {
-        ledger.PrintToTable(acctNum, printTable)
-    }
+    /* Parse the user arguments */
+    ledger.ArgumentParser()
 }

--- a/ledger.go
+++ b/ledger.go
@@ -101,7 +101,7 @@ func (lgr *Ledger) AddEntry(acctNum, store, addr, detail string, cost float64) {
         return
     }
 
-    date := GetDate()
+    date := GetDate(DATE_TIME)
     balance := lgr.Accounts[acctNum].Entry[len(lgr.Accounts[acctNum].Entry) - 1].Balance + cost
     exchange := ternary(cost < 0.00, "Expense", "Income").(string)
 

--- a/ledger.go
+++ b/ledger.go
@@ -97,6 +97,7 @@ func (lgr *Ledger) ParseLedgerLine(data, acctNum string) {
  **/
 func (lgr *Ledger) AddEntry(acctNum, store, addr, detail string, cost float64) {
     if !lgr.IsValidAccount(acctNum) {
+        fmt.Println("Invalid account number:", acctNum)
         return
     }
 

--- a/logFile.go
+++ b/logFile.go
@@ -41,7 +41,7 @@ func NewLog(fname, prefix string) *LogFile {
  * @return: LogFile struct pointer
  **/
 func CreateLogFile(fname, prefix string) *LogFile {
-    filename := ternary(fname != "", fname, GetDate() + ".log").(string)
+    filename := ternary(fname != "", fname, GetDate(DATE_TIME) + ".log").(string)
     f, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
     CheckErr(err)
 
@@ -60,7 +60,7 @@ func CreateLogFile(fname, prefix string) *LogFile {
  * @arg:    acctNum - Account name to save the data if fname is not present
  **/
 func (lgr Ledger) PrintToTable(acctNum, fname string) {
-    filename := GetDate()
+    filename := GetDate(DATE_TIME)
     if fname != "" {
        filename = fname
     } else if (lgr.IsValidAccount(acctNum)) {
@@ -75,6 +75,12 @@ func (lgr Ledger) PrintToTable(acctNum, fname string) {
     CheckErr(err)
 
     lf := log.New(f, "", 0)
+    lf.Println("---")
+    lf.Println("title:", lgr.Accounts[acctNum].Fullname)
+    lf.Println("date:", GetDate(DATE_ONLY))
+    lf.Printf("description: Last transaction - '%s $%0.2f'", lgr.Accounts[acctNum].Entry[len(lgr.Accounts[acctNum].Entry) - 1].Detail, lgr.Accounts[acctNum].Entry[len(lgr.Accounts[acctNum].Entry) - 1].Cost)
+    lf.Println("---")
+
     lf.Println("##### Account Name:", lgr.Accounts[acctNum].Fullname)
     lf.Println("##### Account Number:", acctNum)
     lf.Println("| Date | Transfer To | Description | Cost | Balance |")
@@ -84,7 +90,7 @@ func (lgr Ledger) PrintToTable(acctNum, fname string) {
         if entry.Address != "" {
             ent += "<br>*@" + entry.Address + "*"
         }
-        ent += "|" + entry.Detail + "|" + fmt.Sprintf("%0.2f", entry.Cost) + "|" + fmt.Sprintf("%0.2f", entry.Balance) + "|"
+        ent += "|" + entry.Detail + "|" + fmt.Sprintf("$%0.2f", entry.Cost) + "|" + fmt.Sprintf("$%0.2f", entry.Balance) + "|"
         lf.Println(ent)
     }
 }

--- a/utils.go
+++ b/utils.go
@@ -1,9 +1,13 @@
 package ledger
 
 import (
-    "fmt"
     "strconv"
     "time"
+)
+
+const (
+    DATE_TIME   string = "20060102T150405"
+    DATE_ONLY   string = "2006-01-02"
 )
 
 /**
@@ -69,13 +73,13 @@ func ternary(condition bool, valid, invalid interface{}) interface{} {
 /**
  * @brief:  Get the current date and time
  *
- * @return: The date and time in the format of <YYYYMMDD>T<HHMMSS>
+ * @agr:    The format of which to put the date
+ *
+ * @return: The date and/or time in the format of which the user has entered
  **/
-func GetDate() string {
+func GetDate(format string) string {
     currTime := time.Now()
-    return fmt.Sprintf("%d%02d%02dT%02d%d%d",
-            currTime.Year(), currTime.Month(), currTime.Day(),
-            currTime.Hour(), currTime.Minute(), currTime.Second())
+    return currTime.Format(format)
 }
 
 func FormatDate(date string) string{
@@ -83,7 +87,9 @@ func FormatDate(date string) string{
     fmtDate := date[:4] + "/" + date[4:6] + "/" + date[6:8] + " "
 
     /* Time */
-    fmtDate += date[9:11] + ":" + date[11:13] + ":" + date[13:]
+    if len(date) > 19 {
+        fmtDate += date[12:13] + ":" + date[15:16] + ":" + date[18:19]
+    }
 
     return fmtDate
 }

--- a/utils.go
+++ b/utils.go
@@ -84,11 +84,11 @@ func GetDate(format string) string {
 
 func FormatDate(date string) string{
     /* Date */
-    fmtDate := date[:4] + "/" + date[4:6] + "/" + date[6:8] + " "
+    fmtDate := date[:4] + "/" + date[4:6] + "/" + date[6:8]
 
     /* Time */
-    if len(date) > 19 {
-        fmtDate += date[12:13] + ":" + date[15:16] + ":" + date[18:19]
+    if len(date) == 15 {
+        fmtDate += " " + date[9:11] + ":" + date[11:13] + ":" + date[13:15]
     }
 
     return fmtDate


### PR DESCRIPTION
Instead of hard-coding the account numbers and transaction details, a user argument function is used to add/create entries in the ledger notebook.

Flags that can be used:
`-l`: Pass an existing ledger notebook
`--new-acct`: Create a new account
`--add-entry`: Adds an entry to the ledger notebook
`-pp`: Print the ledger notebook out pretty
`-pt`: Output the ledger notebook as a markdown table